### PR TITLE
Version 0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ MANIFEST
 .pytest_cache
 __pycache__
 hash.json
+*.mhl
 tmp/
 .env
 .venv*/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 envstack
 
-Copyright (c) 2024, Ryan Galloway (ryan@rsgalloway.com)
+Copyright (c) 2024-2025, Ryan Galloway (ryan@rsgalloway.com)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# =============================================================================
+# Project: Hashio - Custom file and directory checksum tool
+# Makefile for building project executables on Linux and Windows (using Wine)
+#
+# Usage:
+#   make           - Builds targets
+#   make clean     - Removes all build artifacts
+#   make install   - Installs the build artifacts using distman
+#
+# Requirements:
+#   - Python and pip installed (Linux)
+#   - Wine installed for Windows builds on Linux
+#   - distman installed for installation (pip install distman)
+# =============================================================================
+
+# Define the installation command
+BUILD_CMD := pip install -r requirements.txt -t build
+
+# Target to build for Linux
+build: clean
+	$(BUILD_CMD)
+
+# Combined target to build for both platforms
+all: build
+
+# Clean target to remove the build directory
+clean:
+	rm -rf build
+
+# Install target to install the builds using distman
+# using --force allows uncommitted changes to be disted
+dryrun:
+	distman --force --dryrun
+
+# Install target to install the builds using distman
+# using --force allows uncommitted changes to be disted
+install: build
+	distman --force --yes
+
+# Phony targets
+.PHONY: build dryrun install clean

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 hashio
 ======
 
-Custom file and directory checksum tool.
+Custom file and directory checksum and verification tool.
 
 ## Features
 
-- multiple hash algos: c4, md5, sha256, sha512, xxh64
+- multiple hash algos: c4, crc32, md5, sha256, sha512, xxh64
 - recursively runs checksums on files in directory trees
 - ignores predefined file name patterns
 - caches results for better performance
@@ -28,7 +28,7 @@ $ hashio <PATH> [--algo <ALGO>]
 ```
 
 Recursively checksum and gather metadata all the files in a dir tree, and output
-results to a JSON file:
+results to a hash.json file:
 
 ```bash
 $ hashio <DIR>
@@ -40,12 +40,13 @@ Verify paths in previously generated JSON file by comparing stored mtimes (if
 available) or regenerated hash values if mtimes are missing or different:
 
 ```bash
-$ hashio --verify hash.json
+$ hashio --verify [HASHFILE]
 ```
 
 ## Environments
 
-You modifiy settings in the environment stack file `hashio.env`, or create a new
+You modifiy settings in the `hashio.env`
+[envstack](https://github.com/rsgalloway/envstack) file, or create a new
 environment stack:
 
 ```bash
@@ -53,6 +54,17 @@ $ cp hashio.env debug.env
 $ vi debug.env  # make edits
 $ ./debug.env -- hashio
 ```
+
+Default config settings are in the config.py module. The following environment
+variables are supported:
+
+| Variable        | Description |
+|-----------------|-------------|
+| $BUF_SIZE       | chunk size in bytes when reading files |
+| $HASHIO_ALGO    | default hashing algorithm to use |
+| $HASHIO_OUTFILE | default output location of hash file |
+| $LOG_LEVEL      | logging level to use (DEBUG, INFO, etc) |
+| $MAX_PROCS      | max number hash processes to spawn |
 
 ## Python API
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,23 @@ results to a hash.json file:
 $ hashio <DIR>
 ```
 
-Note that files matching patterns defined in `config.IGNORABLE` will be skipped.
+#### Ignorable files
 
-Verify paths in previously generated JSON file by comparing stored mtimes (if
+Note that files matching patterns defined in `config.IGNORABLE` will be skipped,
+unless using the `--force` option:
+
+```bash
+$ hashio .git
+path is ignorable: .git
+$ hashio .git --force
+hashing files: 442file [00:00, 1101.47file/s]
+```
+
+Verify paths in previously generated hash file by comparing stored mtimes (if
 available) or regenerated hash values if mtimes are missing or different:
 
 ```bash
-$ hashio --verify [HASHFILE]
+$ hashio --verify hash.json
 ```
 
 #### Portability
@@ -60,8 +70,8 @@ $ hashio --verify hash.json
 
 ## Environment
 
-Default config settings are in the config.py module. The following environment
-variables are supported:
+The following environment variables are supported, and default settings are in
+the config.py module. 
 
 | Variable      | Description |
 |---------------|-------------|

--- a/README.md
+++ b/README.md
@@ -43,22 +43,22 @@ available) or regenerated hash values if mtimes are missing or different:
 $ hashio --verify [HASHFILE]
 ```
 
-#### Relative Paths
+#### Portability
 
-To use relative paths in the hash file to make them portable, use the `--start`
-option:
-
-```bash
-$ hashio <DIR> --start <START>
-```
-
-To verify, use the same `--start` value as when the hash file was created:
+To make a portable hash file, use `--start` to make the paths relative:
 
 ```bash
-$ hashio --verify --start <START>
+$ hashio <DIR> --start <START> -o hash.json
 ```
 
-## Environments
+To verify the data in the hash file, run hashio from the parent dir of the data,
+or set `--start` to the parent dir:
+
+```bash
+$ hashio --verify hash.json
+```
+
+## Environment
 
 You modifiy settings in the `hashio.env`
 [envstack](https://github.com/rsgalloway/envstack) file, or create a new

--- a/README.md
+++ b/README.md
@@ -60,16 +60,6 @@ $ hashio --verify hash.json
 
 ## Environment
 
-You modify settings in the `hashio.env`
-[envstack](https://github.com/rsgalloway/envstack) file, or create a new
-environment stack:
-
-```bash
-$ cp hashio.env debug.env
-$ vi debug.env  # make edits
-$ ./debug.env -- hashio
-```
-
 Default config settings are in the config.py module. The following environment
 variables are supported:
 
@@ -80,6 +70,15 @@ variables are supported:
 | $HASHIO_FILE  | default hash file location |
 | $LOG_LEVEL    | logging level to use (DEBUG, INFO, etc) |
 | $MAX_PROCS    | max number hash processes to spawn |
+
+Optionally, modify the `hashio.env` file if using [envstack](https://github.com/rsgalloway/envstack),
+or create a new env file:
+
+```bash
+$ cp hashio.env debug.env
+$ vi debug.env  # make edits
+$ ./debug.env -- hashio
+```
 
 ## Python API
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ $ ./debug.env -- hashio
 Default config settings are in the config.py module. The following environment
 variables are supported:
 
-| Variable        | Description |
-|-----------------|-------------|
-| $BUF_SIZE       | chunk size in bytes when reading files |
-| $HASHIO_ALGO    | default hashing algorithm to use |
-| $HASHIO_OUTFILE | default output location of hash file |
-| $LOG_LEVEL      | logging level to use (DEBUG, INFO, etc) |
-| $MAX_PROCS      | max number hash processes to spawn |
+| Variable      | Description |
+|---------------|-------------|
+| $BUF_SIZE     | chunk size in bytes when reading files |
+| $HASHIO_ALGO  | default hashing algorithm to use |
+| $HASHIO_FILE  | default hash file location |
+| $LOG_LEVEL    | logging level to use (DEBUG, INFO, etc) |
+| $MAX_PROCS    | max number hash processes to spawn |
 
 ## Python API
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ option:
 $ hashio <DIR> --start <START>
 ```
 
+To verify, use the same `--start` value as when the hash file was created:
+
+```bash
+$ hashio --verify --start <START>
+```
+
 ## Environments
 
 You modifiy settings in the `hashio.env`

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ available) or regenerated hash values if mtimes are missing or different:
 $ hashio --verify [HASHFILE]
 ```
 
+#### Relative Paths
+
+To use relative paths in the hash file to make them portable, use the `--start`
+option:
+
+```bash
+$ hashio <DIR> --start <START>
+```
+
 ## Environments
 
 You modifiy settings in the `hashio.env`
@@ -73,7 +82,7 @@ directory):
 
 ```python
 from hashio.worker import HashWorker
-worker = HashWorker(path)
+worker = HashWorker(path, outfile="hash.json")
 worker.run()
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ hashio --verify hash.json
 
 ## Environment
 
-You modifiy settings in the `hashio.env`
+You modify settings in the `hashio.env`
 [envstack](https://github.com/rsgalloway/envstack) file, or create a new
 environment stack:
 

--- a/hashio.env
+++ b/hashio.env
@@ -4,11 +4,14 @@ all: &all
   LOG_LEVEL: ${LOG_LEVEL:=INFO}
   BUF_SIZE: 65536
   HASHIO_ALGO: ${HASHIO_ALGO:=xxh64}
-  HASHIO_OUTFILE: ${HASHIO_OUTFILE:=hash.json}
+  HASHIO_OUTFILE: ${HASHIO_OUTFILE:=${CACHE_ROOT}/hashio.json}
   MAX_PROCS: ${MAX_PROCS:=10}
 darwin:
   <<: *all
+  CACHE_ROOT: ${HOME}/.cache/hashio
 linux:
   <<: *all
+  CACHE_ROOT: ${HOME}/.cache/hashio
 windows:
   <<: *all
+  CACHE_ROOT: C:/ProgramData/hashio

--- a/hashio.env
+++ b/hashio.env
@@ -4,7 +4,7 @@ all: &all
   LOG_LEVEL: ${LOG_LEVEL:=INFO}
   BUF_SIZE: 65536
   HASHIO_ALGO: ${HASHIO_ALGO:=xxh64}
-  HASHIO_FILE: ${HASHIO_FILE:=${CACHE_ROOT}/hashio.json}
+  HASHIO_FILE: ${HASHIO_FILE:=${CACHE_ROOT}/hash.json}
   MAX_PROCS: ${MAX_PROCS:=10}
 darwin:
   <<: *all

--- a/hashio.env
+++ b/hashio.env
@@ -4,7 +4,7 @@ all: &all
   LOG_LEVEL: ${LOG_LEVEL:=INFO}
   BUF_SIZE: 65536
   HASHIO_ALGO: ${HASHIO_ALGO:=xxh64}
-  HASHIO_OUTFILE: ${HASHIO_OUTFILE:=${CACHE_ROOT}/hashio.json}
+  HASHIO_FILE: ${HASHIO_FILE:=${CACHE_ROOT}/hashio.json}
   MAX_PROCS: ${MAX_PROCS:=10}
 darwin:
   <<: *all

--- a/hashio.env
+++ b/hashio.env
@@ -4,6 +4,7 @@ all: &all
   LOG_LEVEL: ${LOG_LEVEL:=INFO}
   BUF_SIZE: 65536
   HASHIO_ALGO: ${HASHIO_ALGO:=xxh64}
+  HASHIO_OUTFILE: ${HASHIO_OUTFILE:=hash.json}
   MAX_PROCS: ${MAX_PROCS:=10}
 darwin:
   <<: *all

--- a/lib/hashio/__init__.py
+++ b/lib/hashio/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2024, Ryan Galloway (ryan@rsgalloway.com)
+# Copyright (c) 2024-2025, Ryan Galloway (ryan@rsgalloway.com)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/hashio/__init__.py
+++ b/lib/hashio/__init__.py
@@ -35,7 +35,7 @@ Custom file and directory checksum tool.
 
 __author__ = "ryan@rsgalloway.com"
 __prog__ = "hashio"
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 try:
     import envstack

--- a/lib/hashio/cli.py
+++ b/lib/hashio/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2024, Ryan Galloway (ryan@rsgalloway.com)
+# Copyright (c) 2024-2025, Ryan Galloway (ryan@rsgalloway.com)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/hashio/cli.py
+++ b/lib/hashio/cli.py
@@ -146,6 +146,10 @@ def main():
         print(f"path does not exist: {args.path}")
         return 2
 
+    if os.path.isdir(args.outfile):
+        print(f"output file cannot be a directory: {args.outfile}")
+        return 2
+
     if not get_encoder_class(args.algo):
         print(f"unsupported hash algorithm: {args.algo}")
         return 2

--- a/lib/hashio/cli.py
+++ b/lib/hashio/cli.py
@@ -127,10 +127,12 @@ def main():
     # hash verification
     if args.verify is not None:
         if len(args.verify) == 0:
-            for algo, value, miss in verify_checksums(config.CACHE_FILENAME):
+            for algo, value, miss in verify_checksums(
+                config.CACHE_FILENAME, start=args.start
+            ):
                 print("{0} {1}".format(algo, miss))
         elif len(args.verify) == 1:
-            for algo, value, miss in verify_checksums(args.verify[0]):
+            for algo, value, miss in verify_checksums(args.verify[0], start=args.start):
                 print("{0} {1}".format(algo, miss))
         elif len(args.verify) == 2:
             source = args.verify[0]

--- a/lib/hashio/cli.py
+++ b/lib/hashio/cli.py
@@ -55,7 +55,7 @@ def parse_args():
         type=str,
         metavar="PATH",
         nargs="?",
-        help="path to checksum",
+        help="path to directory or files to checksum",
         default=os.getcwd(),
     )
     parser.add_argument(
@@ -63,17 +63,18 @@ def parse_args():
         "--outfile",
         type=str,
         metavar="OUTFILE",
-        help="write results to output OUTFILE",
+        help="write results to OUTFILE",
         default=config.CACHE_FILENAME,
     )
     parser.add_argument(
         "--procs",
         type=int,
         metavar="PROCS",
-        help="max number of spawned processes to use",
+        help="max number of processes to use",
         default=config.MAX_PROCS,
     )
     parser.add_argument(
+        "-s",
         "--start",
         type=str,
         metavar="START",
@@ -81,6 +82,7 @@ def parse_args():
         default=os.getcwd(),
     )
     parser.add_argument(
+        "-a",
         "--algo",
         type=str,
         metavar="ALGO",

--- a/lib/hashio/cli.py
+++ b/lib/hashio/cli.py
@@ -119,12 +119,19 @@ def parse_args():
 
 
 def watch_progress(worker: HashWorker):
-    """Watch the progress of the worker and update a progress bar."""
+    """Watch the progress of the worker and update a progress bar.
+
+    :param worker: HashWorker instance to monitor
+    """
 
     import time
     from tqdm import tqdm
 
-    pbar = tqdm(desc="hashing files", unit="file")
+    pbar = tqdm(
+        desc="hashing files",
+        disable=(worker.verbose or not sys.stdout.isatty()),
+        unit="file",
+    )
     last = 0
 
     while not worker.done.is_set():
@@ -197,12 +204,10 @@ def main():
     )
 
     try:
-        if not args.verbose:
-            watcher = multiprocessing.Process(target=watch_progress, args=(worker,))
-            watcher.start()
+        watcher = multiprocessing.Process(target=watch_progress, args=(worker,))
+        watcher.start()
         worker.run()
-        if not args.verbose:
-            watcher.join()
+        watcher.join()
 
     except KeyboardInterrupt:
         print("stopping...")

--- a/lib/hashio/cli.py
+++ b/lib/hashio/cli.py
@@ -38,7 +38,7 @@ import multiprocessing
 import os
 import sys
 
-from hashio import __version__, config
+from hashio import __version__, config, utils
 from hashio.encoder import get_encoder_class, verify_caches, verify_checksums
 from hashio.logger import logger
 from hashio.worker import HashWorker
@@ -171,6 +171,10 @@ def main():
 
     if not os.path.exists(args.path):
         print(f"path does not exist: {args.path}")
+        return 2
+
+    if utils.is_ignorable(args.path) and not args.force:
+        print(f"path is ignorable: {args.path}")
         return 2
 
     if os.path.isdir(args.outfile):

--- a/lib/hashio/cli.py
+++ b/lib/hashio/cli.py
@@ -142,6 +142,10 @@ def main():
             return 2
         return 0
 
+    if not os.path.exists(args.path):
+        print(f"path does not exist: {args.path}")
+        return 2
+
     if not get_encoder_class(args.algo):
         print(f"unsupported hash algorithm: {args.algo}")
         return 2

--- a/lib/hashio/config.py
+++ b/lib/hashio/config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2024, Ryan Galloway (ryan@rsgalloway.com)
+# Copyright (c) 2024-2025, Ryan Galloway (ryan@rsgalloway.com)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/hashio/config.py
+++ b/lib/hashio/config.py
@@ -30,7 +30,7 @@
 #
 
 __doc__ = """
-Contains configs and settings.
+Contains default hashio configs and settings.
 """
 
 import logging
@@ -52,10 +52,11 @@ IGNORABLE = [
     "*.bak",
     "*.swp",
     "*.tmp",
-    ".git",
-    ".svn",
+    ".git*",
+    ".svn*",
     "dist",
     "build",
+    ".venv*",
     "venv*",
     ".jetpart*",
     "*.egg-info",

--- a/lib/hashio/config.py
+++ b/lib/hashio/config.py
@@ -38,7 +38,7 @@ import os
 import platform
 
 # default output filename
-CACHE_FILENAME = "hash.json"
+CACHE_FILENAME = os.getenv("HASHIO_OUTFILE", "hash.json")
 
 # the default hashing algorithm
 DEFAULT_ALGO = os.getenv("HASHIO_ALGO", "xxh64")

--- a/lib/hashio/config.py
+++ b/lib/hashio/config.py
@@ -47,7 +47,7 @@ CACHE_ROOT = {
         os.environ.get("LOCALAPPDATA", os.path.join(HOME, "AppData", "Local")), "hashio"
     ),
 }.get(PLATFORM)
-CACHE_FILENAME = os.getenv("HASHIO_OUTFILE", os.path.join(CACHE_ROOT, "hash.json"))
+CACHE_FILENAME = os.getenv("HASHIO_FILE", os.path.join(CACHE_ROOT, "hash.json"))
 
 # the default hashing algorithm to use
 DEFAULT_ALGO = os.getenv("HASHIO_ALGO", "xxh64")

--- a/lib/hashio/config.py
+++ b/lib/hashio/config.py
@@ -38,9 +38,18 @@ import os
 import platform
 
 # default output filename
-CACHE_FILENAME = os.getenv("HASHIO_OUTFILE", "hash.json")
+HOME = os.getenv("HOME", os.path.expanduser("~"))
+PLATFORM = platform.system().lower()
+CACHE_ROOT = {
+    "darwin": f"{HOME}/Library/Caches/hashio",
+    "linux": f"{HOME}/.cache/hashio",
+    "windows": os.path.join(
+        os.environ.get("LOCALAPPDATA", os.path.join(HOME, "AppData", "Local")), "hashio"
+    ),
+}.get(PLATFORM)
+CACHE_FILENAME = os.getenv("HASHIO_OUTFILE", os.path.join(CACHE_ROOT, "hash.json"))
 
-# the default hashing algorithm
+# the default hashing algorithm to use
 DEFAULT_ALGO = os.getenv("HASHIO_ALGO", "xxh64")
 
 # ignorable file patterns
@@ -69,14 +78,11 @@ IGNORABLE = [
     "lost_found",
 ]
 
-# logging level
+# default logging level
 LOG_LEVEL = os.getenv("LOG_LEVEL", logging.INFO)
 
-# work in 64KB chunks to limit mem usage when reading large files
+# work in 64KB chunks to limit mem usage for large files
 BUF_SIZE = int(os.getenv("BUF_SIZE", 65536))
 
 # maximum number of search and hash processes to spawn
 MAX_PROCS = int(os.getenv("MAX_PROCS", 10))
-
-# cache the name of the platform (linux or windows)
-PLATFORM = platform.system().lower()

--- a/lib/hashio/encoder.py
+++ b/lib/hashio/encoder.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2024, Ryan Galloway (ryan@rsgalloway.com)
+# Copyright (c) 2024-2025, Ryan Galloway (ryan@rsgalloway.com)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/hashio/encoder.py
+++ b/lib/hashio/encoder.py
@@ -200,6 +200,7 @@ class Encoder(object):
 
     @classmethod
     def get(cls, name: str):
+        """Returns an instance of the encoder class matching the given name."""
         ENCODER_MAP = dict([(sc.name, sc) for sc in Encoder.__subclasses__()])
         encoder_class = ENCODER_MAP.get(name)
         try:
@@ -208,12 +209,15 @@ class Encoder(object):
             raise Exception(f"Invalid encoder: {name}")
 
     def hexdigest(self):
+        """Return the checksum as a hexadecimal string."""
         return self.hash.hexdigest()
 
     def reset(self):
+        """Reset the checksum encoder to its initial state."""
         self.__init__()
 
-    def update(self, data: dict):
+    def update(self, data: bytes):
+        """Update the checksum with the given data."""
         self.hash.update(data)
 
 
@@ -301,6 +305,7 @@ class C4Encoder(SHA512Encoder):
         super(C4Encoder, self).__init__()
 
     def hexdigest(self):
+        """Convert the SHA512 hash to a C4 checksum."""
         hexstr = ""
         shastr = super(C4Encoder, self).hexdigest()
         value = int(shastr, 16)

--- a/lib/hashio/encoder.py
+++ b/lib/hashio/encoder.py
@@ -541,15 +541,13 @@ def dedupe_caches(target: str, source: str, algo: str = config.DEFAULT_ALGO):
     return [(t, s) for t, s in dedupe_cache_gen(target, source, algo=algo)]
 
 
-def verify_checksums(path: str):
+def verify_checksums(path: str, start: str = None):
     """Generator that yields a data tuple for hash misses in a previously
     generated output file. Compares mtimes in the output file with the
     filesystem.
 
-    Currently only supports .json files.
-
-    :param path: path to previously generated cache
-    :yields: tuple of (algo, hash, filepath)
+    :param path: path to hash file
+    :yields: tuple of (algo, hash value, filepath)
     """
     from hashio.exporter import get_exporter_class
 
@@ -559,7 +557,11 @@ def verify_checksums(path: str):
     ext = os.path.splitext(path)[-1]
     exporter_class = get_exporter_class(ext)
     data = exporter_class.read(path)
-    root = os.path.dirname(path)
+
+    if start is None or start == os.getcwd():
+        root = os.path.dirname(path)
+    else:
+        root = start
 
     for filename, metadata in data.items():
         filepath = os.path.join(root, filename)

--- a/lib/hashio/encoder.py
+++ b/lib/hashio/encoder.py
@@ -566,7 +566,6 @@ def verify_checksums(path: str):
 
         # iterate over all the hash algos...
         for algo in ENCODER_MAP.keys():
-            # .. look for the algo in the metadata
             if algo not in metadata.keys():
                 continue
 
@@ -580,8 +579,8 @@ def verify_checksums(path: str):
 
             # if mtimes don't match, re-hash the file
             logger.debug("mtime miss on %s", filepath)
+            old_value = metadata.get(algo)
             encoder = ENCODER_MAP.get(algo)()
-            old_value = metadata[algo]
             new_value = checksum_path(filepath, encoder)
 
             # hash values don't match, file must have changed

--- a/lib/hashio/encoder.py
+++ b/lib/hashio/encoder.py
@@ -104,7 +104,9 @@ def checksum_folder(path: str, encoder: object):
     return value
 
 
-def checksum_path(path, encoder, filetype="a", use_cache=True):
+def checksum_path(
+    path: str, encoder: object, filetype: str = "a", use_cache: bool = True
+):
     """Returns a checksum of for a given path, encoder and filetype.
 
     Note: resets encoder, existing data will be lost.
@@ -164,8 +166,7 @@ class Encoder(object):
         self.hash = hashlib.sha512()
 
     @classmethod
-    def get(cls, name):
-        # TODO: cache this map
+    def get(cls, name: str):
         ENCODER_MAP = dict([(sc.name, sc) for sc in Encoder.__subclasses__()])
         encoder_class = ENCODER_MAP.get(name)
         try:
@@ -281,6 +282,7 @@ def all_encoder_classes(cls: Encoder):
     )
 
 
+# map of encoder names to encoder classes
 ENCODER_MAP = {}
 
 

--- a/lib/hashio/exporter.py
+++ b/lib/hashio/exporter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2024, Ryan Galloway (ryan@rsgalloway.com)
+# Copyright (c) 2024-2025, Ryan Galloway (ryan@rsgalloway.com)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/hashio/exporter.py
+++ b/lib/hashio/exporter.py
@@ -51,8 +51,9 @@ class BaseExporter:
     """Exporter base class."""
 
     def __init__(self, filepath: str):
-        if not os.path.exists(os.path.dirname(filepath)):
-            os.makedirs(os.path.dirname(filepath))
+        dirname = os.path.dirname(filepath)
+        if dirname and not os.path.exists(dirname):
+            os.makedirs(dirname)
         self.filepath = filepath
 
     def close(self):

--- a/lib/hashio/exporter.py
+++ b/lib/hashio/exporter.py
@@ -57,7 +57,7 @@ class BaseExporter:
         raise NotImplementedError
 
     @classmethod
-    def read(self, filepath: str):
+    def read(cls, filepath: str):
         raise NotImplementedError
 
     def write(self):

--- a/lib/hashio/exporter.py
+++ b/lib/hashio/exporter.py
@@ -131,7 +131,7 @@ class JSONExporter(BaseExporter):
         """
 
         # normalize the path relative to the hash file
-        path = normalize_path(
+        npath = normalize_path(
             os.path.abspath(path), start=os.path.dirname(self.filepath)
         )
 
@@ -140,7 +140,7 @@ class JSONExporter(BaseExporter):
             lock = threading.Lock()
             lock.acquire()
             try:
-                f.write('    "{0}": {1},\n'.format(path, json.dumps(data, indent=8)))
+                f.write('    "{0}": {1},\n'.format(npath, json.dumps(data, indent=8)))
             finally:
                 lock.release()
 

--- a/lib/hashio/exporter.py
+++ b/lib/hashio/exporter.py
@@ -137,7 +137,7 @@ class JSONExporter(BaseExporter):
             try:
                 f.write('    "{0}": {1},\n'.format(path, json.dumps(data, indent=8)))
             except Exception as err:
-                logger.warning(f"Write error: {err}")
+                logger.warning("write error: %s", err)
 
 
 class CacheExporter(JSONExporter):

--- a/lib/hashio/exporter.py
+++ b/lib/hashio/exporter.py
@@ -51,6 +51,8 @@ class BaseExporter:
     """Exporter base class."""
 
     def __init__(self, filepath: str):
+        if not os.path.exists(os.path.dirname(filepath)):
+            os.makedirs(os.path.dirname(filepath))
         self.filepath = filepath
 
     def close(self):

--- a/lib/hashio/exporter.py
+++ b/lib/hashio/exporter.py
@@ -50,14 +50,14 @@ class FileExistsError(Exception):
 class BaseExporter:
     """Exporter base class."""
 
-    def __init__(self, filepath):
+    def __init__(self, filepath: str):
         self.filepath = filepath
 
     def close(self):
         raise NotImplementedError
 
     @classmethod
-    def read(self, filepath):
+    def read(self, filepath: str):
         raise NotImplementedError
 
     def write(self):
@@ -70,7 +70,7 @@ class JSONExporter(BaseExporter):
 
     ext = ".json"
 
-    def __init__(self, filepath):
+    def __init__(self, filepath: str):
         super(JSONExporter, self).__init__(filepath)
         fp = open(self.filepath, "w")
         fp.write("{\n")
@@ -92,7 +92,7 @@ class JSONExporter(BaseExporter):
         fp.close()
 
     @classmethod
-    def read(self, filepath):
+    def read(self, filepath: str):
         """Reads and returns the json content at a given filepath, or {} if
         there is an error.
         """
@@ -106,7 +106,7 @@ class JSONExporter(BaseExporter):
             print(err)
             return {}
 
-    def write(self, path, data):
+    def write(self, path: str, data: dict):
         """Writes `data` to file indexed by `path`. The contents of the cache
         file should be data dicts indexed by unique paths.
 
@@ -146,11 +146,11 @@ class CacheExporter(JSONExporter):
 
     ext = ".json"
 
-    def __init__(self, filepath):
+    def __init__(self, filepath: str):
         super(CacheExporter, self).__init__(filepath)
 
     @classmethod
-    def get_cache(cls, path):
+    def get_cache(cls, path: str):
         """Returns the cache filename for a given path.
 
         The cache file will be written to the directory containing the path. For
@@ -163,7 +163,7 @@ class CacheExporter(JSONExporter):
         return os.path.join(dirname, config.CACHE_FILENAME)
 
     @classmethod
-    def find(cls, path, key):
+    def find(cls, path: str, key: str):
         """Searches for path in cached data, and compares mtimes for a given
         path.
 
@@ -210,7 +210,7 @@ class MHLExporter(BaseExporter):
     # MHL timestamp format
     time_format = "%Y-%m-%dT%H:%M:%SZ"
 
-    def __init__(self, filepath):
+    def __init__(self, filepath: str):
         super(MHLExporter, self).__init__(filepath)
         fp = open(self.filepath, "w")
         fp.write(
@@ -224,13 +224,13 @@ class MHLExporter(BaseExporter):
         fp.write("</hashlist>\n")
         fp.close()
 
-    def timestamp(self, ts=None):
+    def timestamp(self, ts: int = None):
         """Converts timestamp to MHL supported time format."""
         if ts is None:
             ts = int(time.time())
         return datetime.utcfromtimestamp(ts).strftime(self.time_format)
 
-    def write(self, path, data):
+    def write(self, path: str, data: dict):
         """Writes out data as MHL-specified XML data.
 
         Example minimum hash element:
@@ -279,7 +279,7 @@ class MHLExporter(BaseExporter):
             f.write((etree.tostring(root, pretty_print=True).decode("utf-8")))
 
 
-def all_exporter_classes(cls):
+def all_exporter_classes(cls: BaseExporter):
     """Returns all exporter classes."""
     return set(cls.__subclasses__()).union(
         [s for c in cls.__subclasses__() for s in all_exporter_classes(c)]
@@ -302,7 +302,7 @@ def build_exporter_map():
 build_exporter_map()
 
 
-def get_exporter_class(ext):
+def get_exporter_class(ext: str):
     """Returns exporter class matching ext."""
     for cls in all_exporter_classes(BaseExporter):
         if cls.ext == ext:

--- a/lib/hashio/exporter.py
+++ b/lib/hashio/exporter.py
@@ -286,6 +286,7 @@ def all_exporter_classes(cls: BaseExporter):
     )
 
 
+# maps of all exporter classes to their extensions
 EXPORTER_MAP = {}
 
 
@@ -299,6 +300,7 @@ def build_exporter_map():
         EXPORTER_MAP[cls.ext] = cls
 
 
+# build the exporter map on import
 build_exporter_map()
 
 

--- a/lib/hashio/exporter.py
+++ b/lib/hashio/exporter.py
@@ -35,11 +35,11 @@ Contains file export classes and functions.
 
 import json
 import os
-import threading
 import time
 from datetime import datetime
 
 from hashio import config
+from hashio.logger import logger
 from hashio.utils import normalize_path
 
 
@@ -115,7 +115,7 @@ class JSONExporter(BaseExporter):
 
     def write(self, path: str, data: dict):
         """
-        Writes `data` to file indexed by `path`. The contents of the cache file
+        Writes `data` to file indexed by `path`. The contents of the hash file
         should be data dicts indexed by unique paths.
 
             {
@@ -133,14 +133,11 @@ class JSONExporter(BaseExporter):
         :param data: the data to write
         """
 
-        # write json serialized data to hash file in a thread-safe manner
         with open(self.filepath, "a+") as f:
-            lock = threading.Lock()
-            lock.acquire()
             try:
                 f.write('    "{0}": {1},\n'.format(path, json.dumps(data, indent=8)))
-            finally:
-                lock.release()
+            except Exception as err:
+                logger.warning(f"Write error: {err}")
 
 
 class CacheExporter(JSONExporter):

--- a/lib/hashio/exporter.py
+++ b/lib/hashio/exporter.py
@@ -130,17 +130,12 @@ class JSONExporter(BaseExporter):
         :param data: the data to write
         """
 
-        # normalize the path relative to the hash file
-        npath = normalize_path(
-            os.path.abspath(path), start=os.path.dirname(self.filepath)
-        )
-
         # write json serialized data to hash file in a thread-safe manner
         with open(self.filepath, "a+") as f:
             lock = threading.Lock()
             lock.acquire()
             try:
-                f.write('    "{0}": {1},\n'.format(npath, json.dumps(data, indent=8)))
+                f.write('    "{0}": {1},\n'.format(path, json.dumps(data, indent=8)))
             finally:
                 lock.release()
 

--- a/lib/hashio/exporter.py
+++ b/lib/hashio/exporter.py
@@ -98,15 +98,14 @@ class JSONExporter(BaseExporter):
         fp.close()
 
     @classmethod
-    def read(self, filepath: str):
+    def read(cls, filepath: str):
         """
         Reads and returns the json content at a given filepath, or {} if there
         is an error.
         """
         try:
-            fp = open(filepath)
-            data = json.load(fp)
-            fp.close()
+            with open(filepath) as fp:
+                data = json.load(fp)
             return data
 
         except json.decoder.JSONDecodeError as err:
@@ -235,7 +234,7 @@ class MHLExporter(BaseExporter):
         return datetime.utcfromtimestamp(ts).strftime(self.time_format)
 
     @classmethod
-    def read(self, filepath: str):
+    def read(cls, filepath: str):
         """Reads MHL data from file and returns a list of dicts.
 
         :param filepath: file path to read

--- a/lib/hashio/logger.py
+++ b/lib/hashio/logger.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2024, Ryan Galloway (ryan@rsgalloway.com)
+# Copyright (c) 2024-2025, Ryan Galloway (ryan@rsgalloway.com)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/hashio/utils.py
+++ b/lib/hashio/utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2024, Ryan Galloway (ryan@rsgalloway.com)
+# Copyright (c) 2024-2025, Ryan Galloway (ryan@rsgalloway.com)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/hashio/utils.py
+++ b/lib/hashio/utils.py
@@ -52,7 +52,7 @@ def get_metadata(path: str):
     stats = os.stat(path)
     path_type = "file" if os.path.isfile(path) else "dir"
     return {
-        "name": os.path.basename(os.path.abspath(path)),
+        "name": os.path.basename(path),
         "atime": stats.st_atime,
         "ctime": stats.st_ctime,
         "mtime": stats.st_mtime,

--- a/lib/hashio/utils.py
+++ b/lib/hashio/utils.py
@@ -45,7 +45,7 @@ ALL_IGNORABLE = re.compile(
 
 
 def get_metadata(path: str):
-    """Returns dict of file metadata.
+    """Returns dict of file metadata: atime, ctime, mtime, ino, dev, size,
 
     Note: disk usage for directories not accurate.
     """
@@ -56,7 +56,8 @@ def get_metadata(path: str):
         "atime": stats.st_atime,
         "ctime": stats.st_ctime,
         "mtime": stats.st_mtime,
-        "inode": stats.st_ino,
+        "ino": stats.st_ino,
+        "dev": stats.st_dev,
         "size": stats.st_size,
         "type": path_type,
     }

--- a/lib/hashio/utils.py
+++ b/lib/hashio/utils.py
@@ -52,11 +52,12 @@ def get_metadata(path):
     stats = os.stat(path)
     path_type = "file" if os.path.isfile(path) else "dir"
     return {
-        "size": stats.st_size,
+        "name": os.path.basename(os.path.abspath(path)),
         "atime": stats.st_atime,
         "ctime": stats.st_ctime,
         "mtime": stats.st_mtime,
-        "name": os.path.basename(os.path.abspath(path)),
+        "inode": stats.st_ino,
+        "size": stats.st_size,
         "type": path_type,
     }
 

--- a/lib/hashio/utils.py
+++ b/lib/hashio/utils.py
@@ -44,7 +44,7 @@ ALL_IGNORABLE = re.compile(
 )
 
 
-def get_metadata(path):
+def get_metadata(path: str):
     """Returns dict of file metadata.
 
     Note: disk usage for directories not accurate.
@@ -62,7 +62,7 @@ def get_metadata(path):
     }
 
 
-def is_ignorable(path):
+def is_ignorable(path: str):
     """Returns True if path is ignorable. Checks path against patterns
     in the ignorables list, as well as dot files.
 
@@ -76,31 +76,48 @@ def is_ignorable(path):
     return re.search(ALL_IGNORABLE, path) is not None
 
 
-def is_subpath(filepath, directory):
-    """Returns True if the common prefix of both is equal
-    to `directory`, e.g. if filepath is /a/b/c/d.rst and
-    directory is /a/b the common prefix is /a/b.
+def is_subpath(filepath: str, directory: str):
+    """Returns True if the common prefix of both is equal to `directory`, e.g.
+    if filepath is /a/b/c/d.rst and directory is /a/b the common prefix is /a/b.
+
+    :param filepath: file system path
+    :param directory: file system path
+    :returns: True if filepath is a subpath of directory
     """
     d = os.path.join(os.path.realpath(directory), "")
     f = os.path.realpath(filepath)
     return os.path.commonprefix([f, d]) == d
 
 
-def normalize_path(path, start=os.getcwd()):
-    """Returns a normalized relative path."""
+def normalize_path(path: str, start: str = os.getcwd()):
+    """Returns a normalized relative path.
+
+    :param path: file system path
+    :param start: path to start from
+    :returns: normalized path
+    """
     npath = os.path.normpath(path)
     if start is None or is_subpath(path, start):
         return os.path.relpath(npath, start=start).replace("\\", "/")
     return os.path.abspath(npath).replace("\\", "/")
 
 
-def paths_are_equal(a, b):
-    """Returns True if path a is the same as path b."""
+def paths_are_equal(a: str, b: str):
+    """Returns True if path a is the same as path b.
+
+    :param a: file system path
+    :param b: file system path
+    :returns: True if paths are equal
+    """
     return normalize_path(a) == normalize_path(b)
 
 
-def read_file(filepath):
-    """File reader data generator."""
+def read_file(filepath: str):
+    """File reader data generator.
+
+    :param filepath: file to read
+    :returns: file data in chunks
+    """
     with open(filepath, "rb") as f:
         while True:
             data = f.read(config.BUF_SIZE)
@@ -109,9 +126,9 @@ def read_file(filepath):
             yield data
 
 
-def walk(path, filetype="f"):
-    """Generator that yields file and dir paths that
-    are not excluded by the ignorable list in config.
+def walk(path: str, filetype: str = "f"):
+    """Generator that yields file and dir paths that are not excluded by the
+    ignorable list in config.
 
     :param path: the path to the folder being hashed
     :param filetype: file (f), dir (d) or all (a)

--- a/lib/hashio/utils.py
+++ b/lib/hashio/utils.py
@@ -70,7 +70,6 @@ def is_ignorable(path: str):
     :param path: file system path
     :returns: True if filename matches pattern in ignorables list
     """
-
     if path.startswith("."):
         return True
 
@@ -147,25 +146,28 @@ def read_file(filepath: str):
             yield data
 
 
-def walk(path: str, filetype: str = "f"):
+def walk(path: str, filetype: str = "f", force: bool = False):
     """Generator that yields file and dir paths that are not excluded by the
     ignorable list in config.
 
     :param path: the path to the folder being hashed
     :param filetype: file (f), dir (d) or all (a)
+    :param force: return all files and directories
     """
-    if not is_ignorable(path) and os.path.isfile(path):
+    if (force or not is_ignorable(path)) and os.path.isfile(path):
         yield path
+
     path = os.path.abspath(path)
+
     for dirname, dirs, files in os.walk(path, topdown=True):
-        if is_ignorable(dirname):
+        if not force and is_ignorable(dirname):
             continue
         for d in dirs:
-            if is_ignorable(d):
+            if not force and is_ignorable(d):
                 dirs.remove(d)
         if filetype in ("a", "f"):
             for name in files:
-                if not is_ignorable(name):
+                if force or not is_ignorable(name):
                     yield os.path.join(dirname, name)
         if filetype in ("a", "d"):
             yield dirname

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2024, Ryan Galloway (ryan@rsgalloway.com)
+# Copyright (c) 2024-2025, Ryan Galloway (ryan@rsgalloway.com)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -208,7 +208,6 @@ class HashWorker:
                 elif task == "hash":
                     worker.do_hash(path)
             except queue.Empty:
-                logger.debug("empty queue: aborting")
                 break
             except Exception as err:
                 logger.error(err)

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -134,13 +134,13 @@ class HashWorker:
         self.start = start or os.path.relpath(path)
         self.encoder = get_encoder_class(algo)()
         self.exporter = get_exporter_class(os.path.splitext(outfile)[1])(outfile)
-        self.queue = Queue()  # queue for tasks
-        self.result_queue = Queue()  # queue for results
+        self.queue = Queue()  # task queue
+        self.result_queue = Queue()  # write queue
         self.pool = Pool(self.procs, HashWorker.main, (self,))
         self.done = Event()
         self.writer = Process(
             target=writer_process, args=(self.result_queue, self.exporter)
-        )  # process to write results
+        )
 
     def __str__(self):
         """Returns a string representation of the worker."""

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -83,20 +83,26 @@ class HashWorker:
         p_name = multiprocessing.current_process().name
         return f"<HashWorker {p_name}>"
 
-    def add_to_queue(self, data):
+    def add_to_queue(self, data: dict):
         """Adds task data to the queue."""
         with self.lock:
             self.queue.put(data)
 
-    def add_path_to_queue(self, path):
-        """Add a directory to the search queue."""
+    def add_path_to_queue(self, path: str):
+        """Add a directory to the search queue.
+
+        :param path: search path
+        """
         self.add_to_queue({"task": "search", "path": path})
 
-    def add_hash_to_queue(self, path):
-        """Add a filename to the hash queue."""
+    def add_hash_to_queue(self, path: str):
+        """Add a filename to the hash queue.
+
+        :param path: file path
+        """
         self.add_to_queue({"task": "hash", "path": path})
 
-    def explore_path(self, path):
+    def explore_path(self, path: str):
         """Walks a dir and adds files to hash queue, and returns a list of
         found subdirs to add to the search queue.
 
@@ -121,8 +127,11 @@ class HashWorker:
                 self.add_hash_to_queue(filename)
         return directories
 
-    def do_hash(self, path):
-        """Checksums a given path and exports metadata."""
+    def do_hash(self, path: str):
+        """Checksums a given path and exports metadata.
+
+        :param path: file path
+        """
         value = checksum_file(path, self.encoder)
         npath = normalize_path(path, start=self.start)
         metadata = get_metadata(path)

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -41,7 +41,7 @@ from multiprocessing import Lock, Pool, Queue
 
 from hashio import config, utils
 from hashio.encoder import checksum_file, get_encoder_class
-from hashio.exporter import CacheExporter
+from hashio.exporter import CacheExporter, get_exporter_class
 from hashio.logger import logger
 from hashio.utils import get_metadata, normalize_path
 
@@ -72,7 +72,7 @@ class HashWorker:
         self.force = force
         self.start = start or os.path.relpath(path)
         self.encoder = get_encoder_class(algo)()
-        self.exporter = CacheExporter(outfile)
+        self.exporter = get_exporter_class(os.path.splitext(outfile)[1])(outfile)
         self.queue = Queue()
         self.lock = Lock()
         self.start_time = 0.0

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -41,7 +41,7 @@ from multiprocessing import Lock, Pool, Queue
 
 from hashio import config, utils
 from hashio.encoder import checksum_file, get_encoder_class
-from hashio.exporter import CacheExporter, get_exporter_class
+from hashio.exporter import get_exporter_class
 from hashio.logger import logger
 from hashio.utils import get_metadata, normalize_path
 
@@ -128,7 +128,8 @@ class HashWorker:
         return directories
 
     def do_hash(self, path: str):
-        """Checksums a given path and exports metadata.
+        """Checksums a given path. Writes the checksum and file metadata to the
+        exporter.
 
         :param path: file path
         """
@@ -141,6 +142,7 @@ class HashWorker:
             self.exporter.write(npath, metadata)
 
     def reset(self):
+        """Resets worker state."""
         self.results = None
         self.total_time = 0.0
 

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -96,9 +96,9 @@ def writer_process(
 class HashWorker:
     """A multiprocessing hash worker class.
 
-        >>> w = HashWorker(path, outfile="hash.json")
-        >>> w.run()
-        >>> pprint(w.results)
+    >>> w = HashWorker(path, outfile="hash.json")
+    >>> w.run()
+    >>> pprint(w.results)
     """
 
     def __init__(

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -171,29 +171,12 @@ class HashWorker:
 
     def explore_path(self, path: str):
         """
-        Walks a dir and adds files to hash queue, and returns a list of found
-        subdirs to add to the search queue.
+        Walks a path and adds files to hash queue.
 
         :param path: search path
         """
-        directories = []
-        nondirectories = []
-        if self.force:
-            if os.path.isdir(path):
-                for filename in os.listdir(path):
-                    fullname = os.path.join(path, filename)
-                    if os.path.isdir(fullname):
-                        directories.append(fullname)
-                    else:
-                        nondirectories.append(fullname)
-            else:
-                nondirectories.append(path)
-            for filename in nondirectories:
-                self.add_hash_to_queue(filename)
-        else:
-            for filename in utils.walk(path, filetype="f"):
-                self.add_hash_to_queue(filename)
-        return directories
+        for filename in utils.walk(path, filetype="f", force=self.force):
+            self.add_hash_to_queue(filename)
 
     def do_hash(self, path: str):
         """
@@ -263,9 +246,7 @@ class HashWorker:
                 task = data["task"]
                 path = data["path"]
                 if task == "search":
-                    dirs = worker.explore_path(path)
-                    for newdir in dirs:
-                        worker.add_path_to_queue(newdir)
+                    worker.explore_path(path)
                 elif task == "hash":
                     worker.do_hash(path)
             except queue.Empty:

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -55,20 +55,30 @@ CWD = os.getcwd()
 class HashWorker:
     """A multiprocessing hash worker class.
 
-    >>> w = HashWorker(path)
-    >>> w.run()
-    >>> pprint(w.results)
+        >>> w = HashWorker(path, outfile="hash.json")
+        >>> w.run()
+        >>> pprint(w.results)
     """
 
     def __init__(
         self,
-        path=os.getcwd(),
-        outfile=config.CACHE_FILENAME,
-        procs=config.MAX_PROCS,
-        start=None,
-        algo=config.DEFAULT_ALGO,
-        force=False,
+        path: str = os.getcwd(),
+        outfile: str = config.CACHE_FILENAME,
+        procs: int = config.MAX_PROCS,
+        start: str = None,
+        algo: str = config.DEFAULT_ALGO,
+        force: bool =False,
     ):
+        """Initializes a HashWorker instance.
+
+        :param path: path to search for files to hash
+        :param outfile: output file to write results to
+        :param procs: maximum number of processes to use
+        :param start: starting path for relative paths in output
+        :param algo: hashing algorithm to use
+        :param force: if True, force hashing of all files in the directory
+            regardless of file type or existence in cache
+        """
         self.path = path
         self.outfile = outfile
         self.procs = procs
@@ -83,6 +93,7 @@ class HashWorker:
         self.results = None
 
     def __str__(self):
+        """Returns a string representation of the worker."""
         p_name = multiprocessing.current_process().name
         return f"<HashWorker {p_name}>"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-envstack>=0.8.3
+envstack>=0.8.9
 xxhash==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 envstack>=0.8.9
+lxml==5.3.0
+tqdm==4.67.1
 xxhash==3.5.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2024, Ryan Galloway (ryan@rsgalloway.com)
+# Copyright (c) 2024-2025, Ryan Galloway (ryan@rsgalloway.com)
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         ],
     },
     install_requires=[
-        "envstack>=0.8.",
+        "envstack>=0.8.3",
         "xxhash==3.5.0",
     ],
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open(os.path.join(here, "README.md")) as f:
 
 setup(
     name="hashio",
-    version="0.2.1",
+    version="0.3.0",
     description="Custom file and directory checksum tool",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -72,7 +72,7 @@ setup(
         ],
     },
     install_requires=[
-        "envstack>=0.8.3",
+        "envstack>=0.8.",
         "xxhash==3.5.0",
     ],
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ setup(
         ],
     },
     install_requires=[
-        "envstack>=0.8.3",
         "xxhash==3.5.0",
     ],
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,8 @@ setup(
         ],
     },
     install_requires=[
+        "lxml==5.3.0",
+        "tqdm==4.67.1",
         "xxhash==3.5.0",
     ],
     python_requires=">=3.6",


### PR DESCRIPTION
Version 0.3.0 RC

- adds support for crc32 (resolves issue #3 )
- adds st_ino (inode) to metadata (resolves issue #7 )
- makes cwd the default starting directory (resolves issue #6 and #5 )
- replaces queue polling with task counter and sentinal approach
- uses buffered write process instead of direct writes to hash file
- adds tqdm progress bar as default stdout
- adds type hints
- adds initial Makefile
- bumps version to 0.3.0
