### PR TITLE
Version 0.4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,3 +221,12 @@ from hashio.encoder import checksum_folder, XXH64Encoder
 encoder = XXH64Encoder()
 value = checksum_folder(folder, encoder)
 ```
+
+## Cache
+
+Run the following command to safely apply the latest schema updates and create
+any missing indexes:
+
+```bash
+$ hashio --update-cache
+```

--- a/README.md
+++ b/README.md
@@ -195,6 +195,43 @@ This prints a summary of file-level changes between two snapshots:
 ~ file was modified
 ```
 
+## Read Buffer Size Optimization
+
+By default, `hashio` uses a fixed read buffer size set in `config.py`. This
+conservative default works well across most systems, but it can be suboptimal
+on filesystems with large block sizes (e.g. network-attached storage).
+
+#### Optional: Enable Dynamic Buffer Sizing
+
+Dynamic read buffer sizing can be enabled to reduce IOPS and improve performance
+on sequential reads. When enabled:
+
+- Filesystem block size is determined via `os.statvfs(path).f_frsize`.
+- If the block size is large (≥ 128 KiB), it is used directly
+- If the block size is small, it is scaled up and clamped
+
+#### Configuration
+
+You can configure buffer size using the `BUF_SIZE` environment variable:
+
+- If `BUF_SIZE` is set to a positive integer, that value is used
+- If `BUF_SIZE` is 0 or a negative value, dynamic buffer sizing is enabled
+- If `BUF_SIZE` is unset, the default fixed size from `config.py` is used
+
+This can be configured either:
+- In your `hashio.env` file (if using [envstack](https://github.com/rsgalloway/envstack)), or
+- Directly in the environment
+
+#### Examples
+
+```bash
+# use a fixed 512 KiB read buffer
+export BUF_SIZE=524288
+
+# enable dynamic sizing based on block size
+export BUF_SIZE=0
+```
+
 ## Python API
 
 Generate a `hash.json` file for a given path (Default is the current working

--- a/hashio.env
+++ b/hashio.env
@@ -2,7 +2,7 @@
 include: [default]
 all: &all
   LOG_LEVEL: ${LOG_LEVEL:=INFO}
-  BUF_SIZE: 65536
+  BUF_SIZE: ${BUF_SIZE:=1048576}
   HASHIO_ALGO: ${HASHIO_ALGO:=xxh64}
   HASHIO_DB: ${HASHIO_DB:=${CACHE_ROOT}/hash.sql}
   HASHIO_FILE: ${HASHIO_FILE:=hash.json}

--- a/hashio.env
+++ b/hashio.env
@@ -7,6 +7,7 @@ all: &all
   HASHIO_DB: ${HASHIO_DB:=${CACHE_ROOT}/hash.sql}
   HASHIO_FILE: ${HASHIO_FILE:=hash.json}
   MAX_PROCS: ${MAX_PROCS:=10}
+  MERGE_INTERVAL: ${MERGE_INTERVAL:=5}
 darwin:
   <<: *all
   CACHE_ROOT: ${HOME}/.cache/hashio

--- a/lib/hashio/__init__.py
+++ b/lib/hashio/__init__.py
@@ -36,11 +36,3 @@ Custom file and directory checksum tool.
 __author__ = "ryan@rsgalloway.com"
 __prog__ = "hashio"
 __version__ = "0.4.6"
-
-try:
-    import envstack
-
-    envstack.init(__prog__)
-
-except Exception as e:
-    pass

--- a/lib/hashio/__init__.py
+++ b/lib/hashio/__init__.py
@@ -35,7 +35,7 @@ Custom file and directory checksum tool.
 
 __author__ = "ryan@rsgalloway.com"
 __prog__ = "hashio"
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 try:
     import envstack

--- a/lib/hashio/cache.py
+++ b/lib/hashio/cache.py
@@ -198,6 +198,11 @@ class Cache:
         # create indexes for faster lookups
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_files_path ON files(path)")
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_files_algo ON files(algo)")
+        self.conn.execute("CREATE INDEX IF NOT EXISTS idx_files_hash ON files(hash)")
+        self.conn.execute("CREATE INDEX IF NOT EXISTS idx_files_inode ON files(inode)")
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_files_hash_inode ON files(hash, inode)"
+        )
         self.conn.commit()
 
     def flush(self):

--- a/lib/hashio/cache.py
+++ b/lib/hashio/cache.py
@@ -53,6 +53,7 @@ LOCK_MESSAGES = [
     "database schema is locked",
     "database table is locked",
     "database is busy",
+    "already in use",
 ]
 
 
@@ -290,6 +291,7 @@ class Cache:
         row = cur.fetchone()
         return row[0] if row else None
 
+    @with_retry()
     def merge(self, path: str):
         """Merge another database into this cache. This will insert all unique
         entries from the other database into the current cache. This will lock
@@ -413,6 +415,7 @@ class Cache:
         self.conn.commit()
         return cur.lastrowid
 
+    @with_retry()
     def replace_snapshot(self, name: str, path: str = None):
         """Deletes any existing snapshot with the same name and creates a fresh one.
 

--- a/lib/hashio/cache.py
+++ b/lib/hashio/cache.py
@@ -201,8 +201,12 @@ class Cache:
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_files_algo ON files(algo)")
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_files_hash ON files(hash)")
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_files_inode ON files(inode)")
+        self.conn.execute("CREATE INDEX IF NOT EXISTS idx_files_mtime ON files(mtime)")
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_files_hash_inode ON files(hash, inode)"
+        )
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_files_path_mtime_algo ON files(path, mtime, algo)"
         )
         self.conn.commit()
 
@@ -291,7 +295,7 @@ class Cache:
         row = cur.fetchone()
         return row[0] if row else None
 
-    @with_retry()
+    @with_retry(retries=10)
     def merge(self, path: str):
         """Merge another database into this cache. This will insert all unique
         entries from the other database into the current cache. This will lock

--- a/lib/hashio/cache.py
+++ b/lib/hashio/cache.py
@@ -295,7 +295,7 @@ class Cache:
         entries from the other database into the current cache. This will lock
         the database for the duration of the merge.
 
-        :param other_db_path: The path to the other SQLite database file.
+        :param path: The path to the other SQLite database file.
         """
         self.conn.execute("ATTACH DATABASE ? AS tempdb", (path,))
         # do not insert IDs

--- a/lib/hashio/cli.py
+++ b/lib/hashio/cli.py
@@ -269,8 +269,6 @@ def main():
 
     # validate and update the cache
     if args.update_cache:
-        from hashio.cache import Cache
-
         cache = Cache()
         cache._ensure_db()
         cache.close()

--- a/lib/hashio/cli.py
+++ b/lib/hashio/cli.py
@@ -130,6 +130,7 @@ def parse_args():
         help="skip ignorables",
     )
     parser.add_argument(
+        "-s",
         "--summarize",
         action="store_true",
         help="show summary of results",

--- a/lib/hashio/cli.py
+++ b/lib/hashio/cli.py
@@ -135,6 +135,11 @@ def parse_args():
         help="show summary of results",
     )
     parser.add_argument(
+        "--update-cache",
+        action="store_true",
+        help="apply the latest schema updates and create any missing indexes",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="count",
@@ -262,8 +267,18 @@ def main():
 
     args = parse_args()
 
+    # validate and update the cache
+    if args.update_cache:
+        from hashio.cache import Cache
+
+        cache = Cache()
+        cache._ensure_db()
+        cache.close()
+        print("Cache DB updated.")
+        return 0
+
     # query cache or list all entries
-    if args.query:
+    elif args.query:
         cache = Cache()
         results = cache.query(args.query, args.algo, args.since)
         if results:

--- a/lib/hashio/config.py
+++ b/lib/hashio/config.py
@@ -48,10 +48,13 @@ CACHE_ROOT = {
     ),
 }.get(PLATFORM)
 
+# stores temporary worker cache files
+TEMP_CACHE_DIR = os.path.join(CACHE_ROOT, "temp")
+
 # default cache filename
 CACHE_FILENAME = os.getenv("HASHIO_FILE", "hash.json")
 
-# default database path
+# default central database filename
 DEFAULT_DB_PATH = os.getenv("HASHIO_DB", os.path.join(CACHE_ROOT, "hash.sql"))
 
 # the default hashing algorithm to use

--- a/lib/hashio/config.py
+++ b/lib/hashio/config.py
@@ -109,3 +109,6 @@ BUF_SIZE = safe_eval(os.getenv("BUF_SIZE", 1024 * 1024))
 
 # maximum number of search and hash processes to spawn
 MAX_PROCS = safe_eval(os.getenv("MAX_PROCS", 10))
+
+# default merge interval in seconds
+MERGE_INTERVAL = safe_eval(os.getenv("MERGE_INTERVAL", 5))

--- a/lib/hashio/config.py
+++ b/lib/hashio/config.py
@@ -33,9 +33,15 @@ __doc__ = """
 Contains default hashio configs and settings.
 """
 
+import envstack
 import logging
 import os
 import platform
+
+from envstack.util import safe_eval
+
+envstack.init("hashio")
+
 
 # default output filename
 HOME = os.getenv("HOME", os.path.expanduser("~"))
@@ -97,8 +103,9 @@ IGNORABLE = os.getenv("HASHIO_IGNORABLE", ",".join(IGNORABLE)).split(",")
 # default logging level
 LOG_LEVEL = os.getenv("LOG_LEVEL", logging.INFO)
 
-# work in 64KB chunks to limit mem usage for large files
-BUF_SIZE = int(os.getenv("BUF_SIZE", 65536))
+# set the read buffer size for file reads. change this value to optimize performance
+# or limit memory usage. default is 1MB.
+BUF_SIZE = safe_eval(os.getenv("BUF_SIZE", 1024 * 1024))
 
 # maximum number of search and hash processes to spawn
-MAX_PROCS = int(os.getenv("MAX_PROCS", 10))
+MAX_PROCS = safe_eval(os.getenv("MAX_PROCS", 10))

--- a/lib/hashio/encoder.py
+++ b/lib/hashio/encoder.py
@@ -302,7 +302,7 @@ def get_encoder_class(name: str):
     return
 
 
-def checksum_data(data: bytes, encoder: Encoder):
+def checksum_data(data: bytes, encoder: Encoder, buffer_size: int = config.BUF_SIZE):
     """Checksum contents from a binary stream. Data should be a byte string.
     Note: resets encoder, existing data will be lost.
 
@@ -310,17 +310,18 @@ def checksum_data(data: bytes, encoder: Encoder):
 
     :param data: the byte string data to hash
     :param encoder: instance of Encoder subclass
+    :param buffer_size: size of each read chunk in bytes ($BUF_SIZE)
     :return: hexdigest of the checksum
     """
     encoder.reset()
-    for i in range(0, len(data), config.BUF_SIZE):
-        encoder.update(data[i : i + config.BUF_SIZE])
+    for i in range(0, len(data), buffer_size):
+        encoder.update(data[i : i + buffer_size])
     value = encoder.hexdigest()
     encoder.reset()
     return value
 
 
-def checksum_file(path: str, encoder: Encoder):
+def checksum_file(path: str, encoder: Encoder, buffer_size: int = config.BUF_SIZE):
     """Creates a checksum for a given filepath and encoder. Note: resets
     encoder, existing data will be lost.
 
@@ -331,7 +332,7 @@ def checksum_file(path: str, encoder: Encoder):
     :return: hexdigest of the checksum
     """
     encoder.reset()
-    for data in read_file(path):
+    for data in read_file(path, buffer_size=buffer_size):
         encoder.update(data)
     value = encoder.hexdigest()
     encoder.reset()

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -111,6 +111,7 @@ class HashWorker:
         """
         self.path = path
         self.algo = algo
+        self.buffer_size = utils.get_buffer_size(path=path)
         self.outfile = outfile
         self.snapshot = snapshot
         self.procs = procs
@@ -165,6 +166,7 @@ class HashWorker:
         :param path: search path
         """
         logger.debug("Exploring path %s", path)
+        logger.debug("Using read buffer size: %s", self.buffer_size)
         for filename in utils.walk(path, filetype="f", force=self.force):
             self.add_hash_to_queue(filename)
 
@@ -207,7 +209,7 @@ class HashWorker:
             do_write = True
             try:
                 encoder = get_encoder(self.algo)
-                value = checksum_file(path, encoder)
+                value = checksum_file(path, encoder, buffer_size=self.buffer_size)
                 metadata[self.algo] = value
             except OSError as e:
                 logger.debug(str(e))

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -255,11 +255,12 @@ class HashWorker:
 
         if self.temp_cache is None:
             pid = os.getpid()
-            dbname = f"worker_{pid}_{uuid.uuid4().hex}.sql"
-            self.temp_db_path = os.path.join(config.TEMP_CACHE_DIR, dbname)
-            self.temp_cache = Cache(self.temp_db_path)
-            logger.debug("Adding worker cache to queue: %s", self.temp_db_path)
-            self.temp_db_queue.put(self.temp_db_path)
+            with self.lock:
+                dbname = f"worker_{pid}_{uuid.uuid4().hex}.sql"
+                self.temp_db_path = os.path.join(config.TEMP_CACHE_DIR, dbname)
+                self.temp_cache = Cache(self.temp_db_path)
+                logger.debug("Adding worker cache to queue: %s", self.temp_db_path)
+                self.temp_db_queue.put(self.temp_db_path)
 
         npath = data.get("normalized_path")
         abspath = data.get("abs_path")

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -117,7 +117,9 @@ def writer_process(
     buffer = []
     last_flush = time.time()
 
-    cache = Cache() if use_cache else None
+    temp_db_path = f"{path}/.hashio_worker_{os.getpid()}.sql"
+    cache = Cache(temp_db_path) if use_cache else None
+
     snapshot_id = (
         cache.replace_snapshot(snapshot_name, path)
         if (cache and snapshot_name)

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -296,7 +296,6 @@ class HashWorker:
             self.temp_cache.batch_add_snapshot_links(snapshot_id, snapshot_file_ids)
 
         self.temp_cache.commit()
-        # self.temp_cache.close()
 
     def update_current_file(self, path: str):
         """Updates the current file in shared memory."""

--- a/lib/hashio/worker.py
+++ b/lib/hashio/worker.py
@@ -184,7 +184,8 @@ class HashWorker:
         size = metadata["size"]
 
         # get the global cache instance
-        cache = Cache()
+        with self.lock:
+            cache = Cache()
 
         # normalize the path for consistent output
         normalized_path = normalize_path(path, start=self.start)
@@ -314,7 +315,9 @@ class HashWorker:
             self.temp_cache.commit()
 
         # merge the temporary caches into the main cache
-        main_cache = Cache()
+        with self.lock:
+            main_cache = Cache()
+
         merged_paths = set()
 
         while not self.temp_db_queue.empty():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-envstack>=0.8.9
+envstack==0.8.9
 lxml==5.3.0
 tqdm==4.67.1
 xxhash==3.5.0

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
         ],
     },
     install_requires=[
+        "envstack==0.8.9",
         "lxml==5.3.0",
         "tqdm==4.67.1",
         "xxhash==3.5.0",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ except ModuleNotFoundError:
 
 setup(
     name="hashio",
-    version="0.4.5",
+    version="0.4.6",
     description="Custom file and directory checksum tool",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_retry_fail.py
+++ b/tests/test_retry_fail.py
@@ -32,6 +32,7 @@ def reset_hashio_env(tmp_path):
 
 
 def test_hashworker_retries_on_locked_cache(monkeypatch, tmp_path):
+    """Test that HashWorker retries when the cache is locked by another process."""
 
     from hashio.cache import Cache
     from hashio.worker import HashWorker
@@ -59,7 +60,10 @@ def test_hashworker_retries_on_locked_cache(monkeypatch, tmp_path):
 
     # run the worker
     worker = HashWorker(str(file_path), force=True, verbose=True)
-    worker.run()
+
+    # this should raise RuntimeError due to the lock
+    with pytest.raises(RuntimeError) as exc_info:
+        worker.run()
 
     locker.join()
 


### PR DESCRIPTION
Version 0.4.6 RC

- shard temp caches per worker subprocess
- merge to main periodically and on flush
- adds indexes on hash and inode
- adds dynamic read buffer option
- adds --update-cache cli option to migrate existing cache files
- bumps version to 0.4.6
- addresses #42 
- addresses #41 
- addresses #39 